### PR TITLE
add <netinet/in.h> to tiny68k.c, gcc could not find htons

### DIFF
--- a/tiny68k.c
+++ b/tiny68k.c
@@ -10,6 +10,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <netinet/in.h>
 #include "v68.h"
 #include "m68k.h"
 #include "m68kcpu.h"


### PR DESCRIPTION
When running `make` on my system, gcc produced the following errors:

```
gcc -O2 -Wall -pedantic   -c -o tiny68k.o tiny68k.c
tiny68k.c: In function ‘cpu_read_word’:
tiny68k.c:512:24: error: implicit declaration of function ‘htons’ [-Wimplicit-function-declaration]
  512 |                 return htons(ide_read16(ide, (address & 31) >> 1));
      |                        ^~~~~
tiny68k.c: In function ‘cpu_write_word’:
tiny68k.c:562:55: error: implicit declaration of function ‘ntohs’ [-Wimplicit-function-declaration]
  562 |                 ide_write16(ide, (address & 31) >> 1, ntohs(value));
      |                                                       ^~~~~
make: *** [<builtin>: tiny68k.o] Error 1
```

Adding `#include <netinet/in.h>` to `tiny68k.c` fixes this error, as per https://linux.die.net/man/3/htons.